### PR TITLE
Correct encoding for `mov`

### DIFF
--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -24,7 +24,7 @@ INSTRUCTIONS = {
     "and": 0x6,
     "test": 0x7,
 
-    "mov": 0x8,
+    "mov": 0x9,
 
     "load": 0xA, "ld": 0xA,
     "store": 0xB, "st": 0xB,


### PR DESCRIPTION
Should be 0x9, not 0x8.