### PR TITLE
Stack and functions

### DIFF
--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -212,7 +212,7 @@ def base_jumps(context, inst: str, symbol: str):
     else:
         offset = target - context.ip
     reject(not (-256 <= offset < 256))
-    return build((0b100, 3), (offset & 100 >> 8, 1), (op, 4), (offset & 0xFF, 8))
+    return build((0b100, 3), (offset & 0x100 >> 8, 1), (op, 4), (offset & 0xFF, 8))
 
 
 @base.inst('"nop"')

--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -203,7 +203,7 @@ def base_jumps(context, inst: str, symbol: str):
     else:
         offset = target - context.ip
     reject(not (-256 <= offset < 256))
-    return build((0b100, 3), (offset & 0x100 >> 8, 1), (op, 4), (offset & 0xFF, 8))
+    return build((0b100, 3), (offset < 0, 1), (op, 4), (offset & 0xFF, 8))
 
 
 @base.inst('"nop"')

--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -129,7 +129,7 @@ def base_computations_imm(context, inst: str, inst_size: str | None, reg: tuple[
 
     op = INSTRUCTIONS[inst]
 
-    if op < 12:
+    if op <= 7 or op == 9:
         reject(not isinstance(imm, int) or not (-16 <= imm < 16),
                f"Invalid immediate for base {imm} with opcode {inst}")
     else:

--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -207,11 +207,11 @@ CONDITION_NAMES = {
     "mp": 14, "": 14,
 }
 
-@base.inst(f'/j{oneof(*CONDITION_NAMES)}/ label')
-def base_jumps(context, inst: str, label: str):
+@base.inst(f'/j{oneof(*CONDITION_NAMES)}/ symbol')
+def base_jumps(context, inst: str, symbol: str):
     inst = inst.removeprefix('j')
     op = CONDITION_NAMES[inst]
-    target = context.resolve_label(label)
+    target = context.resolve_symbol(symbol)
     if target is None:
         offset = 0
     else:

--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -189,7 +189,7 @@ def mov_to_mem(context, size, dest, source):
     """)
 
 
-JUMP_NAMES = {
+CONDITION_NAMES = {
     "z": 0, "e": 0,
     "nz": 1, "ne": 1,
     "n": 2,
@@ -204,13 +204,13 @@ JUMP_NAMES = {
     "ge": 11,
     "le": 12,
     "g": 13, "gt": 13,
-    "mp": 14,
+    "mp": 14, "": 14,
 }
 
-@base.inst(f'/j{oneof(*JUMP_NAMES)}/ label')
+@base.inst(f'/j{oneof(*CONDITION_NAMES)}/ label')
 def base_jumps(context, inst: str, label: str):
     inst = inst.removeprefix('j')
-    op = JUMP_NAMES[inst]
+    op = CONDITION_NAMES[inst]
     target = context.resolve_label(label)
     if target is None:
         offset = 0
@@ -223,3 +223,7 @@ def base_jumps(context, inst: str, label: str):
 @base.inst('"nop"')
 def base_nop(context):
     return b"\x8f\x00"  # jump nowhere, never
+
+@base.inst('"hlt"')
+def base_hlt(context):
+    return b"\x8e\x00"  # jump nowhere, always

--- a/etca_asm/base_isa.py
+++ b/etca_asm/base_isa.py
@@ -1,7 +1,7 @@
 from bitarray import bitarray
 from bitarray.util import int2ba
 
-from etca_asm.core import Extension, reject, resolve_register_size
+from etca_asm.core import Extension, reject, resolve_register_size, oneof
 
 base = Extension(None, "base", "Base Instruction Set", True)
 
@@ -37,11 +37,6 @@ INSTRUCTIONS = {
     "mfcr": 0xE,
     "mtcr": 0xF,
 }
-
-
-def oneof(*names):
-    names=sorted(names, key=len, reverse=True)
-    return f"({'|'.join(names)})"
 
 
 def build(*parts: tuple[int, int]):

--- a/etca_asm/core.py
+++ b/etca_asm/core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from ast import literal_eval
-from cgitb import enable
 
 import copy
 import logging

--- a/etca_asm/core.py
+++ b/etca_asm/core.py
@@ -170,7 +170,8 @@ def local_symbol_reference(context, dots, name: str):
     return len(dots), str(name)
 
 
-@core.inst(r'".extension" /\w+/ ( "," /\w+/)*')
+@core.inst(r'".extension" /\w+/')
+@core.inst(r'".extensions" /\w+/ ( "," /\w+/)*')
 def enable_extension(context, *names: str):
     for name in names:
         if name not in context.available_extensions:

--- a/etca_asm/core.py
+++ b/etca_asm/core.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+from ast import literal_eval
 from cgitb import enable
 
 import copy
@@ -175,10 +177,12 @@ def enable_extension(context, *names: str):
     context.reload_extensions()
 
 
-core.register_syntax('immediate', '/[+-]?[0-9]+(_[0-9]+)*/', lambda _, x: int(str(x), 10))
-core.register_syntax('immediate', '/[+-]?0[bB]_?[01]+(_[01]+)*/', lambda _, x: int(x[2:].removeprefix('_'), 2))
-core.register_syntax('immediate', '/[+-]?0[oO]_?[0-7]+(_[0-7]+)*/', lambda _, x: int(x[2:].removeprefix('_'), 8))
-core.register_syntax('immediate', '/[+-]?0x_?[0-9a-f]+(_[0-9a-f]+)*/i', lambda _, x: int(x[2:].removeprefix('_'), 16))
+core.register_syntax('immediate', r'/[+-]?[0-9]+(_[0-9]+)*/', lambda _, x: int(str(x), 10))
+core.register_syntax('immediate', r'/[+-]?0[bB]_?[01]+(_[01]+)*/', lambda _, x: int(x[2:].removeprefix('_'), 2))
+core.register_syntax('immediate', r'/[+-]?0[oO]_?[0-7]+(_[0-7]+)*/', lambda _, x: int(x[2:].removeprefix('_'), 8))
+core.register_syntax('immediate', r'/[+-]?0x_?[0-9a-f]+(_[0-9a-f]+)*/i', lambda _, x: int(x[2:].removeprefix('_'), 16))
+
+core.register_syntax('immediate', r"/'([^'\\\n]|\\[^\n])'/", lambda _, x: ord(literal_eval(x)))
 
 
 @core.register_syntax('immediate', 'symbol')

--- a/etca_asm/extensions/stack_and_functions.py
+++ b/etca_asm/extensions/stack_and_functions.py
@@ -20,9 +20,9 @@ REGISTERS = {
 def fn_ptr_registers(cxt, name, size):
     return size, REGISTERS[name]
 
-@functions.reg(fr'"%" /(a|v|s)/ size_infix /(?!<\s)[0-1]/')
+@functions.reg(fr'"%" /(a|v|s)/ size_infix /(?!<\s)[0-2]/')
 #@functions.reg(fr'/(a|v|s)/ size_infix /[0-1]/', prefix=False)
-@functions.reg(fr'/(a|v|s)/ size_infix /(?!<\s)[0-1]/', prefix=False)
+@functions.reg(fr'/(a|v|s)/ size_infix /(?!<\s)[0-2]/', prefix=False)
 def fn_gp_registers(cxt, pref, size, suff):
     name = pref + suff
     reject(not name in REGISTERS.keys(), f"Unknown register name `{name}'")

--- a/etca_asm/extensions/stack_and_functions.py
+++ b/etca_asm/extensions/stack_and_functions.py
@@ -1,13 +1,8 @@
-from wsgiref import validate
-from etca_asm.core import Extension, reject
+from etca_asm.core import Extension, reject, oneof
 from etca_asm.base_isa import CONDITION_NAMES, validate_registers, build
 
 functions = Extension(2, "functions", "Stack and Functions")
 Register = tuple[int | None, int]
-
-def oneof(*names):
-    names=sorted(names, key=len, reverse=True)
-    return f"({'|'.join(names)})"
 
 REGISTERS = {
     "a0": 0,

--- a/etca_asm/extensions/stack_and_functions.py
+++ b/etca_asm/extensions/stack_and_functions.py
@@ -1,0 +1,90 @@
+from wsgiref import validate
+from etca_asm.core import Extension, reject
+from etca_asm.base_isa import CONDITION_NAMES, validate_registers, build
+
+functions = Extension(2, "functions", "Stack and Functions")
+Register = tuple[int | None, int]
+
+def oneof(*names):
+    names=sorted(names, key=len, reverse=True)
+    return f"({'|'.join(names)})"
+
+REGISTERS = {
+    "a0": 0,
+    "a1": 1,
+    "v0": 2,
+    "s0": 3,
+    "s1": 4,
+    "bp": 5,
+    "sp": 6,
+    "ln": 7,
+}
+
+@functions.reg(fr'"%" /(bp|sp|ln)/ size_postfix')
+@functions.reg(fr'/(bp|sp|ln)/ size_postfix', prefix=False)
+def fn_ptr_registers(cxt, name, size):
+    return size, REGISTERS[name]
+
+@functions.reg(fr'"%" /(a|v|s)/ size_infix /(?!<\s)[0-1]/')
+#@functions.reg(fr'/(a|v|s)/ size_infix /[0-1]/', prefix=False)
+@functions.reg(fr'/(a|v|s)/ size_infix /(?!<\s)[0-1]/', prefix=False)
+def fn_gp_registers(cxt, pref, size, suff):
+    name = pref + suff
+    reject(not name in REGISTERS.keys(), f"Unknown register name `{name}'")
+    return size, REGISTERS[name]
+
+@functions.inst(f'"pop" size_postfix register')
+def pop_inst(cxt, inst_size, reg: Register):
+    size, (dst,) = validate_registers(cxt, reg, inst_size=inst_size)
+    return build((0b00,2), (cxt.register_sizes[size],2), (0xC,4), (dst,3), (0b00000,5))
+
+@functions.inst(f'"push" size_postfix register')
+def push_register_inst(cxt, inst_size, reg: Register):
+    size, (src,) = validate_registers(cxt, reg, inst_size=inst_size)
+    return build((0b00,2), (cxt.register_sizes[size],2), (0xD,4), (0b000,3), (src,3), (0b00,2))
+
+@functions.inst(f'"push" size_postfix immediate')
+def push_register_imm(cxt, inst_size, imm: int):
+    size, () = validate_registers(cxt, inst_size=inst_size)
+    reject(
+        not isinstance(imm, int) or not (0 <= imm < 32),
+        f"Invalidate immediate {imm} for op `push'"
+    )
+    return build((0b01,2), (cxt.register_sizes[size],2), (0xD,4), (0b000,3), (imm,5))
+
+@functions.inst(f'/j{oneof(*CONDITION_NAMES)}/ register')
+def cond_abs_reg_jump(cxt, inst: str, reg: Register):
+    _,(src,) = validate_registers(cxt, reg)
+    cc = inst.removeprefix('j')
+    op = CONDITION_NAMES[cc]
+    return build((0xAF,8), (src,3), (0b0,1), (op,4))
+
+@functions.inst(f'/ret{oneof(*CONDITION_NAMES)}/')
+def cond_return(cxt, inst: str):
+    cc = inst.removeprefix('ret')
+    reject(cc == 'mp', "`mp' is not a valid conditional return suffix")
+    op = CONDITION_NAMES[cc]
+    return build((0xAF,8), (0b111,3), (0b0,1), (op,4))
+
+@functions.inst(f'/call{oneof(*CONDITION_NAMES)}/ register')
+def cond_abs_reg_call(cxt, inst: str, reg: Register):
+    _,(src,) = validate_registers(cxt, reg)
+    cc = inst.removeprefix('call')
+    reject(cc == 'mp', "`mp' is not a valid conditional call suffix")
+    op = CONDITION_NAMES[cc]
+    return build((0xAF,8), (src,3), (0b1,1), (op,4))
+
+@functions.inst('"call" label')
+def abs_near_call(cxt, lbl: str):
+    target = cxt.resolve_label(lbl)
+    if target is None:
+        target = cxt.ip
+    bottom_mask = 0xfff
+    top_mask = ~bottom_mask
+    reject(
+        (top_mask & target) != (top_mask & cxt.ip),
+        f"""Cannot encode far call:
+    from `call {lbl}'     at 0x{cxt.ip:04x}
+    to   `{lbl}' resolved to 0x{target:04x}"""
+    )
+    return build((0xB,4), (bottom_mask & target, 12))

--- a/etca_asm/extensions/stack_and_functions.py
+++ b/etca_asm/extensions/stack_and_functions.py
@@ -74,9 +74,9 @@ def cond_abs_reg_call(cxt, inst: str, reg: Register):
     op = CONDITION_NAMES[cc]
     return build((0xAF,8), (src,3), (0b1,1), (op,4))
 
-@functions.inst('"call" label')
+@functions.inst('"call" symbol')
 def abs_near_call(cxt, lbl: str):
-    target = cxt.resolve_label(lbl)
+    target = cxt.resolve_symbol(lbl)
     if target is None:
         target = cxt.ip
     bottom_mask = 0xfff

--- a/etca_asm/extensions/stack_and_functions.py
+++ b/etca_asm/extensions/stack_and_functions.py
@@ -7,7 +7,7 @@ Register = tuple[int | None, int]
 REGISTERS = {
     "a0": 0,
     "a1": 1,
-    "v0": 2,
+    "a2": 2,
     "s0": 3,
     "s1": 4,
     "bp": 5,
@@ -45,7 +45,7 @@ def push_register_imm(cxt, inst_size, imm: int):
         not isinstance(imm, int) or not (0 <= imm < 32),
         f"Invalidate immediate {imm} for op `push'"
     )
-    return build((0b01,2), (cxt.register_sizes[size],2), (0xD,4), (0b000,3), (imm,5))
+    return build((0b01,2), (cxt.register_sizes[size],2), (0xD,4), (6,3), (imm,5))
 
 @functions.inst(f'/j{oneof(*CONDITION_NAMES)}/ register')
 def cond_abs_reg_jump(cxt, inst: str, reg: Register):

--- a/test.py
+++ b/test.py
@@ -10,29 +10,8 @@ etca_asm.extensions.import_all_extensions()
 ass = Assembler()
 
 res = ass.n_pass("""
-.extension byte_operations,functions
-    mov     ax0, 5
-    call    fib
-    hlt
-fib:
-    mov     vh0, ah0
-    cmp     ax0, 1
-    retbe
-    push    lnx
-    push    sx0
-    sub     ah0, 1
-    push    ax0
-    call    fib
-    mov     sh0, vh0
-    pop     ax0
-    sub     ah0, 1
-    call    fib
-    add     vh0, sh0
-    pop     sx0
-    pop     lnx
-    ret
-
-
+.set test 555
+.dword test
 """)
 
 print(res.to_bytes().hex(' ', 2))

--- a/test.py
+++ b/test.py
@@ -10,10 +10,29 @@ etca_asm.extensions.import_all_extensions()
 ass = Assembler()
 
 res = ass.n_pass("""
-.syntax prefix
-.strict
-.extension byte_operations, dword_operations, qword_operations
-movx %rx0, 1000
+.extension byte_operations,functions
+    mov     ax0, 5
+    call    fib
+    hlt
+fib:
+    mov     vh0, ah0
+    cmp     ax0, 1
+    retbe
+    push    lnx
+    push    sx0
+    sub     ah0, 1
+    push    ax0
+    call    fib
+    mov     sh0, vh0
+    pop     ax0
+    sub     ah0, 1
+    call    fib
+    add     vh0, sh0
+    pop     sx0
+    pop     lnx
+    ret
+
+
 """)
 
 print(res.to_bytes().hex(' ', 2))

--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ etca_asm.extensions.import_all_extensions()
 ass = Assembler()
 
 res = ass.n_pass("""
-.set test 555
+.set test '\\n'
 .dword test
 """)
 


### PR DESCRIPTION
Brings in the stack & functions extension as well as some minor fixes I had locally.

Additionally brings in several new features from Mega which were intended to go straight to master:
  - `.set SYMBOL VALUE` directive, for creating named constants
  - `.half/.word/.dword`, for including literal data in the binary
  - support for character literals
  - bugfixes related to the previous pass system's reset mechanism