### PR TITLE
Hack install system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,116 @@
+# Makefile for simple-as-possible etc-as installation.
+
+BUILD_DIR   := .build
+BUILD_LOCAL := $(abspath $(BUILD_DIR)/local)
+LOCAL_LIB   := $(BUILD_LOCAL)/lib
+LOCAL_BIN   := $(BUILD_LOCAL)/bin
+
+INSTALL_PREFIX := /usr
+INSTALL_BIN    ?= $(INSTALL_PREFIX)/bin
+INSTALL_LIB    ?= $(INSTALL_PREFIX)/lib/etc-as
+
+ETC_AS_BIN := $(BUILD_DIR)$(INSTALL_BIN)
+ETC_AS_LIB := $(BUILD_DIR)$(INSTALL_LIB)
+
+ETC_AS := etc-as
+
+ETC_AS_VERSION ?= $(shell cat etca_asm/version)
+ETC_AS_RELEASE ?= v$(ETC_AS_VERSION)-$(shell git rev-parse --short HEAD)
+
+.PHONY: all build clean deps test install uninstall
+
+all: build
+
+clean:
+	rm -rf $(ETC_AS_BIN) $(ETC_AS_LIB)
+
+test:
+	cd tests/golden && $(MAKE) test
+
+# "Building"
+# Prepare the files for copy by moving only the ones that we need to
+# a local .build directory.
+
+etc_as_files :=                     \
+	etc-as.py                       \
+	etca_asm/__init__.py            \
+	etca_asm/base_isa.py            \
+	etca_asm/common_macros.py       \
+	etca_asm/core.py                \
+	etca_asm/instruction.lark       \
+	etca_asm/extensions/__init__.py \
+	etca_asm/extensions/byte_operations.py \
+	etca_asm/extensions/dword_operations.py \
+	etca_asm/extensions/qword_operations.py \
+	etca_asm/extensions/stack_and_functions.py
+
+$(ETC_AS_LIB)/%.py: %.py
+	@mkdir -p $(dir $@)
+	install $< $@
+
+$(ETC_AS_LIB)/%.lark: %.lark
+	@mkdir -p $(dir $@)
+	install $< $@
+
+# Installing
+# Put everything in `/usr/` space
+
+install_bins := $(ETC_AS)
+install_libs := $(etc_as_files) version
+
+build_bins := $(install_bins)
+build_libs := $(install_libs)
+
+$(ETC_AS_BIN)/$(ETC_AS): $(ETC_AS)
+	@mkdir -p $(dir $@)
+	install $< $@
+
+$(ETC_AS_LIB)/version:
+	@mkdir -p $(dir $@)
+	echo $(ETC_AS_RELEASE) > $@
+
+build: $(patsubst %, $(ETC_AS_BIN)/%, $(install_bins)) \
+       $(patsubst %, $(ETC_AS_LIB)/%, $(install_libs))
+
+all_bin_sources := $(shell find $(ETC_AS_BIN) -type f | sed 's|^$(ETC_AS_BIN)/||')
+all_lib_sources := $(shell find $(ETC_AS_LIB) -type f | sed 's|^$(ETC_AS_LIB)/||')
+
+install: $(patsubst %, $(DESTDIR)$(INSTALL_BIN)/%, $(all_bin_sources)) \
+         $(patsubst %, $(DESTDIR)$(INSTALL_LIB)/%, $(all_lib_sources))
+
+$(DESTDIR)$(INSTALL_BIN)/%: $(ETC_AS_BIN)/%
+	@mkdir -p $(dir $@)
+	install $< $@
+
+$(DESTDIR)$(INSTALL_LIB)/%: $(ETC_AS_LIB)/%
+	@mkdir -p $(dir $@)
+	install $< $@
+
+uninstall:
+	rm -rf $(DESTDIR)$(INSTALL_BIN)/$(ETC_AS)
+	rm -rf $(DESTDIR)$(INSTALL_LIB)
+
+# Install dependencies if they aren't present
+
+APT_VERSION := $(shell apt-get --version)
+PYTHON_3_10 ?= python3.10
+PYTHON_3_10_VERSION := $(shell $(PYTHON_3_10) --version)
+
+ifeq (,$(APT_VERSION))
+deps:
+	$(error Sorry, the dependency install walkthrough only works on apt-based systems. Check the README and do a manual install.)
+else
+deps: python310 python-packages
+endif
+
+python310:
+ifeq (,$(PYTHON_3_10_VERSION))
+	echo "This install walkthrough is going to use sudo several times, which requires a password."
+	echo "Please only use this tool if you trust us, and feel free to ask what each step is doing."
+	sudo apt install software-properties-common -y
+	sudo add-apt-repository ppa:deadsnakes/ppa
+	sudo apt install $(PYTHON_3_10)
+endif
+
+python-packages: python310
+	$(PYTHON_3_10) -m pip install lark frozendict bitarray

--- a/README.md
+++ b/README.md
@@ -6,7 +6,31 @@ One of the goals is that it's at least reasoanbly easy to add extensions.
 
 ## Installation
 
+This assembler was not aimed at being easy to use for those unfamiliar with a terminal. However, after some
+requests from members of the Turing Complete discord server, we've added a simple installation system
+that should walk you through getting everything required to use the assembler as easily as possible.
+
+As always, _be careful_ when using `sudo`. You are giving programs administrator access to your machine.
+You can see what commands will be run in the `Makefile` if you'd like to vet it for yourself.
+
+### Dependency Installer
+
+Run `sudo make deps` to get help installing the dependencies needed for `etc-as`. This command only works on
+Debian-based Linux distributions, such as Ubuntu.
+
 `python3.10` is needed. Then the packages `lark`, `frozendict` and `bitarray` need to be installed.
 
+The dependency installation helper will install `python3.10` using the PPA (Personal Package Archive)
+from the lovely people at deadsnakes. Then it will install the needed packages through python itself.
+
+### One-Time Installation
+
+From this repository, run `sudo make install`. This will install the `etc-as` as downloaded to your machine.
+Afterwards, you should be able to run `etc-as` from any folder to see help text.
+
 ## Usage
+
 The primary interface should be the frontend module `etc-as.py`, to be used similar the standard command `as`. For extended help, do `etc-as.py -h`.
+
+The wrapper script `etc-as` can also be used instead. It tries to be helpful by doing a (naive) check for python versions that will work. After
+`make install`, `etc-as` is the entrypoint that is expected to be used.

--- a/etc-as
+++ b/etc-as
@@ -29,7 +29,7 @@ if [[ $# -eq 0 ]] ; then
     set -- "--help"
 fi
 
-if [[ "${1:-}" == 'version' ]] || [[ "${1:-}" == '--version' ]] ; then
+if [[ "${1:-}" == '-V' ]] || [[ "${1:-}" == '--version' ]] ; then
     echo "$0"
     cat  "$INSTALL_LIB"/version
     exit 0

--- a/etc-as
+++ b/etc-as
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s extglob
+
+ETC_AS=etc-as
+
+check_python310_install() {
+    which python3.10 $> /dev/null \
+        || fatal "Must have python3.10 installed. Try the `make deps` target that came with etc-as."
+}
+
+INSTALL_BIN="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_LIB="$(dirname "$INSTALL_BIN")/lib/$ETC_AS"
+
+run_etcas() {
+    python3.10 "$INSTALL_LIB/etc-as.py" "$@"
+}
+
+if [[ $# -eq 0 ]] ; then
+    set -- "--help"
+fi
+
+if [[ "${1:-}" == 'version' ]] || [[ "${1:-}" == '--version' ]] ; then
+    echo "$0"
+    cat  "$INSTALL_LIB"/version
+    exit 0
+fi
+
+run_etcas "$@"

--- a/etc-as
+++ b/etc-as
@@ -4,17 +4,25 @@ set -euo pipefail
 shopt -s extglob
 
 ETC_AS=etc-as
+PYTHON3=python3
+
+fatal() { echo "[FATAL] $@" >&2 ; exit 1 ; }
+
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 check_python310_install() {
-    which python3.10 $> /dev/null \
-        || fatal "Must have python3.10 installed. Try the `make deps` target that came with etc-as."
+    if ! [ $(version $(python3 --version)) -ge $(version "3.10.0") ] ; then
+        PYTHON3=python3.10
+    fi
+    which $PYTHON3 &> /dev/null \
+        || fatal "Must have python3.10 or newer installed. Try the \`make deps\` target that came with etc-as."
 }
 
 INSTALL_BIN="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_LIB="$(dirname "$INSTALL_BIN")/lib/$ETC_AS"
 
 run_etcas() {
-    python3.10 "$INSTALL_LIB/etc-as.py" "$@"
+    $PYTHON3 "$INSTALL_LIB/etc-as.py" "$@"
 }
 
 if [[ $# -eq 0 ]] ; then
@@ -27,4 +35,5 @@ if [[ "${1:-}" == 'version' ]] || [[ "${1:-}" == '--version' ]] ; then
     exit 0
 fi
 
+check_python310_install
 run_etcas "$@"


### PR DESCRIPTION
This PR adds a hacky install system intended to be used by beginners / newcomers to the ETCa space who are not terminal-fluent. It is as easy-to-use as possible, and should require just
```bash
$ sudo make deps
$ sudo make install
```
to check for `python3.10`, install it if not present, and then install required dependency packages. The `install` target then copies all of our relevant files into `/usr/...` so that they are accessible on the path. Then `$ etc-as` will run the interpreter from anywhere. I felt that it was better to keep these as separate targets, but of course `install` could be made to depend on `deps` if we want.

The `etc-as` script also attempts to flexibly use `python3` instead of `python3.10` if the version is more recent than `3.10.0`. However `sudo make deps` is not so smart and looks for `python3.10` explicitly. If this turns out to be a problem, I think I could fix it, but this is simpler.