### PR TITLE
Fix dep installer, update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,6 @@ build: $(patsubst %, $(ETC_AS_BIN)/%, $(install_bins)) \
 all_bin_sources := $(shell find $(ETC_AS_BIN) -type f | sed 's|^$(ETC_AS_BIN)/||')
 all_lib_sources := $(shell find $(ETC_AS_LIB) -type f | sed 's|^$(ETC_AS_LIB)/||')
 
-install: $(patsubst %, $(DESTDIR)$(INSTALL_BIN)/%, $(all_bin_sources)) \
-         $(patsubst %, $(DESTDIR)$(INSTALL_LIB)/%, $(all_lib_sources))
-
 $(DESTDIR)$(INSTALL_BIN)/%: $(ETC_AS_BIN)/%
 	@mkdir -p $(dir $@)
 	install $< $@
@@ -85,6 +82,9 @@ $(DESTDIR)$(INSTALL_BIN)/%: $(ETC_AS_BIN)/%
 $(DESTDIR)$(INSTALL_LIB)/%: $(ETC_AS_LIB)/%
 	@mkdir -p $(dir $@)
 	install $< $@
+
+install: $(patsubst %, $(DESTDIR)$(INSTALL_BIN)/%, $(all_bin_sources)) \
+         $(patsubst %, $(DESTDIR)$(INSTALL_LIB)/%, $(all_lib_sources))
 
 uninstall:
 	rm -rf $(DESTDIR)$(INSTALL_BIN)/$(ETC_AS)
@@ -95,12 +95,13 @@ uninstall:
 APT_VERSION := $(shell apt-get --version)
 PYTHON_3_10 ?= python3.10
 PYTHON_3_10_VERSION := $(shell $(PYTHON_3_10) --version)
+PIP_3_10_VERSION := $(shell $(PYTHON_3_10) -m pip --version)
 
 ifeq (,$(APT_VERSION))
 deps:
 	$(error Sorry, the dependency install walkthrough only works on apt-based systems. Check the README and do a manual install.)
 else
-deps: python310 python-packages
+deps: python310 python310-pip python-packages
 endif
 
 python310:
@@ -110,6 +111,11 @@ ifeq (,$(PYTHON_3_10_VERSION))
 	sudo apt install software-properties-common -y
 	sudo add-apt-repository ppa:deadsnakes/ppa
 	sudo apt install $(PYTHON_3_10)
+endif
+
+python310-pip:
+ifeq (,$(PIP_3_10_VERSION))
+	sudo apt install python3-pip
 endif
 
 python-packages: python310

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ from the lovely people at deadsnakes. Then it will install the needed packages t
 ### One-Time Installation
 
 From this repository, run `make build && sudo make install`.
-This will install `etc-as` to your machine. Not that it will install whatever you cloned from github -
+This will install `etc-as` to your machine. Note that it will install whatever you cloned from github -
 you'll need to `git pull` first if you want to install updates from our repository.
 
 Afterwards, you should be able to run `etc-as` from any folder to see help text.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ from the lovely people at deadsnakes. Then it will install the needed packages t
 
 ### One-Time Installation
 
-From this repository, run `sudo make install`. This will install the `etc-as` as downloaded to your machine.
+From this repository, run `make build && sudo make install`.
+This will install the `etc-as` as downloaded to your machine.
 Afterwards, you should be able to run `etc-as` from any folder to see help text.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ from the lovely people at deadsnakes. Then it will install the needed packages t
 ### One-Time Installation
 
 From this repository, run `make build && sudo make install`.
-This will install the `etc-as` as downloaded to your machine.
+This will install `etc-as` to your machine. Not that it will install whatever you cloned from github -
+you'll need to `git pull` first if you want to install updates from our repository.
+
 Afterwards, you should be able to run `etc-as` from any folder to see help text.
 
 ## Usage


### PR DESCRIPTION
The dependency installer didn't install `pip`, which I did not realize is stripped in debian-based systems. Who knows why. There's now a separate target which runs `sudo apt install python3-pip`. I _believe_ that each version of python provides its own pip compat through `python3.XX -m pip` so the lack of specificity to python3.10 here should be fine.

I also updated the README; you must run `make build` separately from `sudo make install`. The `make build` target prepares the files that will be copied to `/usr` into a `./.build` directory and it is a bad idea to have the Makefile skip this step on the off chance that something could go wrong.