### PR TITLE
Added support for byte_operations to common_macros.py, fix tc-64 output

### DIFF
--- a/etca_asm/common_macros.py
+++ b/etca_asm/common_macros.py
@@ -16,7 +16,9 @@ def split_into_bit_groups(imm):
 @common_macros.inst('"mov" register_raw "," immediate')
 def mov_large_immediate(context, reg, imm):
     reject_msg = f'Immediate is too large to fit in a register: {imm}'
-    if -2**15 <= imm <= 2**16 - 1:
+    if -2**7 <= imm <= 2**8 - 1 and 'h':
+        size = 'h'
+    elif -2**15 <= imm <= 2**16 - 1:
         size = 'x'
     elif -2**31 <= imm <= 2**32 - 1:
         reject(not any(map(lambda x: x.strid == 'dword_operations', context.enabled_extensions)), reject_msg)


### PR DESCRIPTION
`mov %rh0, '0'` compiles now.

I had the fixes for tc-64 laying around for some time, I am not sure what exactly the problem was. I think it tried to generate too long words in some situations.