### PR TITLE
Update readme with the current spec url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # etca-asm
 
-A basic implementation of an assembler for [ETCa](https://github.com/MegaIng/ETC.a). 
+A basic implementation of an assembler for [ETCa](https://github.com/ETC-A/etca-spec). 
 This is not supposed to be permanent solution and therefore this is not well designed everywhere. 
 One of the goals is that it's at least reasoanbly easy to add extensions.
 


### PR DESCRIPTION
It currently isn't a problem, but it's probably better to not rely on GitHub's old-url redirect mechanic.